### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/TrustlabTech/Amply-Platform.png?label=ready&title=Ready)](https://waffle.io/TrustlabTech/Amply-Platform?utm_source=badge)
 # Amply-Trustlab
 
 <img src="https://cloud.githubusercontent.com/assets/25197053/24645519/bbfcedd0-1918-11e7-9763-a42d9d4935c5.jpg" alt="Amply Logo" width="150" height="150">


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/TrustlabTech/Amply-Platform

This was requested by a real person (user lsconsent) on waffle.io, we're not trying to spam you.